### PR TITLE
#14 Fix work document prefix when creating embeddings

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   build-embeddings:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-m
 
     steps:
       - name: Cancel previous runs
@@ -40,7 +40,7 @@ jobs:
 
   build-and-test-python:
     needs: [build-embeddings]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-m
 
     steps:
     - uses: actions/checkout@v3
@@ -62,7 +62,7 @@ jobs:
   build-embeddings-latest:
     if: github.ref == 'refs/heads/main'
     needs: [build-and-test-python]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-m
 
     steps:
       - name: Cancel previous runs
@@ -89,7 +89,7 @@ jobs:
   deploy:
     needs: [build-and-test-python, build-embeddings-latest]
     if: github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-m
     steps:
     - uses: actions/checkout@v2
     - name: Azure authentication

--- a/app/embeddings.py
+++ b/app/embeddings.py
@@ -356,7 +356,7 @@ class Chroma():
         if not self.collections.get(collection_name):
             raise NoCollectionException(f'Please create or load the collection {collection_name}')
         for embedding_item in embeddings_json['data'].get('data') or []:
-            prefix = 'work_'
+            prefix = ''
             suffix = ''
             item_id = embeddings_json['work']
             if embeddings_json['video']:

--- a/app/embeddings.py
+++ b/app/embeddings.py
@@ -320,7 +320,7 @@ def work_id_from_item_id(item_id):
             except (IndexError, ValueError):
                 pass
         elif item_id_parts[0] == 'work':
-            work_id = item_id_parts[1]
+            work_id = item_id_parts[-1]
     else:
         work_id = item_id
     return work_id
@@ -358,7 +358,7 @@ class Chroma():
         for embedding_item in embeddings_json['data'].get('data') or []:
             prefix = 'work_'
             suffix = ''
-            item_id = f"work_{embeddings_json['work']}"
+            item_id = embeddings_json['work']
             if embeddings_json['video']:
                 prefix = 'video_'
                 item_id = f"{embeddings_json['video']['id']}_{embeddings_json['video']['work_id']}"


### PR DESCRIPTION
Resolves #14

A bug was introduced when creating works embeddings so that works had a double prefix `work_work_119830` instead of `119830`. Let's fix that and make it backwards compatible with the old database and with the [website works explorer](https://www.acmi.net.au/works/explore/).

### Acceptance Criteria
- [x] Remove the double `work_` prefix for work documents when creating embeddings

### Relevant design files
* None

### Testing instructions
1. Delete your `works_db`
1. Set `REBUILD=true`
1. Re-build: `make build`
1. Note the home page loads works: http://localhost:8081/?json=false