### PR TITLE
#16 Fix slow boot

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -191,7 +191,7 @@ ignored-classes=optparse.Values,thread._local,_thread._local
 # (useful for modules/projects where namespaces are manipulated during runtime
 # and thus existing member attributes cannot be deduced by static analysis. It
 # supports qualified module names, as well as Unix pattern matching.
-ignored-modules=
+ignored-modules=PIL,chromadb,open_clip
 
 # Show a hint with possible names when a member name was not found. The aspect
 # of finding the hint is based on edit distance.

--- a/app/embeddings.py
+++ b/app/embeddings.py
@@ -31,6 +31,8 @@ CHROMA = None
 OPENCLIP = None
 SELECTED_WORK_ID = None
 SUCCESSFUL_TAP = None
+LOADING = False
+LOADED = False
 
 
 def normalise_distance(distance, min_distance=30, max_distance=1200):
@@ -70,7 +72,7 @@ def home():
     work = request.args.get('work', None)
     size = int(request.args.get('size', '11'))
     global SELECTED_WORK_ID  # pylint: disable=global-statement
-    embeddings = CHROMA.embeddings.get('works')
+    embeddings = CHROMA.embeddings.get('works') if CHROMA else []
     filtered_embeddings = embeddings
 
     if work:
@@ -133,10 +135,10 @@ def video_and_image_response(page_request):  # pylint: disable=too-many-branches
     size = int(page_request.args.get('size', '11'))
     path = page_request.path.replace('/', '')
     global SELECTED_WORK_ID  # pylint: disable=global-statement
-    embeddings = CHROMA.embeddings.get(path)
+    embeddings = CHROMA.embeddings.get(path) if CHROMA else []
     filtered_embeddings = embeddings
 
-    if (image or text) and TEXT_SEARCH:
+    if (image or text) and TEXT_SEARCH and OPENCLIP and CHROMA:
         SELECTED_WORK_ID = None
         # Create OpenCLIP embedding of the query
         clip = OPENCLIP.get_embeddings(image=image, text_string=text, openai_format=False)[0]
@@ -556,31 +558,64 @@ class XOSAPI():  # pylint: disable=too-few-public-methods
         return None
 
 
-with application.app_context():
-    print('===================================')
-    if not OPENCLIP and TEXT_SEARCH:
-        print('Starting up OpenCLIP...')
-        OPENCLIP = ImageEmbedding()
-    if not CHROMA:
-        CHROMA = Chroma()
-        CHROMA.get_collection()
-        if REBUILD:
-            print('Rebuilding the collection...')
-            CHROMA.add_pages_of_embeddings()
-            print('Finished works...')
+def run_loader():
+    """
+    Loads OpenCLIP and Chroma embeddings into memory.
+    """
+    global OPENCLIP  # pylint: disable=global-statement
+    global CHROMA  # pylint: disable=global-statement
+    global LOADED  # pylint: disable=global-statement
+    with application.app_context():
+        print('===================================')
+        if not OPENCLIP and TEXT_SEARCH:
+            print('Starting up OpenCLIP...')
+            OPENCLIP = ImageEmbedding()
+        if not CHROMA:
+            CHROMA = Chroma()
+            CHROMA.get_collection()
+            if REBUILD:
+                print('Rebuilding the collection...')
+                CHROMA.add_pages_of_embeddings()
+                print('Finished works...')
+                CHROMA.get_collection('videos')
+                CHROMA.add_pages_of_embeddings(embedding_type='videos')
+                print('Finished videos...')
+                CHROMA.get_collection('images')
+                CHROMA.add_pages_of_embeddings(embedding_type='images')
+                print('Finished images...')
+            print(f'Loading embeddings from {DATABASE_PATH}...')
+            CHROMA.load_embeddings()
             CHROMA.get_collection('videos')
-            CHROMA.add_pages_of_embeddings(embedding_type='videos')
-            print('Finished videos...')
+            CHROMA.load_embeddings('videos')
             CHROMA.get_collection('images')
-            CHROMA.add_pages_of_embeddings(embedding_type='images')
-            print('Finished images...')
-        print(f'Loading embeddings from {DATABASE_PATH}...')
-        CHROMA.load_embeddings()
-        CHROMA.get_collection('videos')
-        CHROMA.load_embeddings('videos')
-        CHROMA.get_collection('images')
-        CHROMA.load_embeddings('images')
-    print('===================================')
+            CHROMA.load_embeddings('images')
+        LOADED = True
+        print('===================================')
+
+
+@application.route('/load', methods=['GET', 'POST'])
+def load():
+    """
+    Loads embeddings and models once the server is running.
+    """
+    global LOADING  # pylint: disable=global-statement
+    if LOADED:
+        return jsonify({'status': 'loaded'})
+    if LOADING:
+        return jsonify({'status': 'loading'}), 202
+
+    LOADING = True
+    try:
+        run_loader()
+        return jsonify({'status': 'loaded'})
+    except Exception as exception:  # pylint: disable=broad-except
+        return jsonify({'status': 'error', 'error': str(exception)}), 500
+    finally:
+        LOADING = False
+
+
+if not os.getenv('PRODUCTION', 'false').lower() == 'true':
+    run_loader()
 
 
 if __name__ == '__main__':

--- a/app/embeddings.py
+++ b/app/embeddings.py
@@ -1,15 +1,16 @@
 import json
 import os
 import random
-import time
 import subprocess
-import requests
-from flask import Flask, jsonify, render_template, request, Response
-from PIL import Image
+import threading
+import time
 
 import chromadb
 import open_clip
+import requests
 import torch
+from flask import Flask, Response, jsonify, render_template, request
+from PIL import Image
 
 DEBUG = os.getenv('DEBUG', 'false').lower() == 'true'
 REBUILD = os.getenv('REBUILD', 'false').lower() == 'true'
@@ -33,6 +34,7 @@ SELECTED_WORK_ID = None
 SUCCESSFUL_TAP = None
 LOADING = False
 LOADED = False
+LOAD_ERROR = None
 
 
 def normalise_distance(distance, min_distance=30, max_distance=1200):
@@ -593,25 +595,53 @@ def run_loader():
         print('===================================')
 
 
+def run_loader_in_background():
+    """
+    Wrapper for background loading state management.
+    """
+    global LOADING  # pylint: disable=global-statement
+    global LOAD_ERROR  # pylint: disable=global-statement
+    try:
+        run_loader()
+    except Exception as exception:  # pylint: disable=broad-except
+        LOAD_ERROR = str(exception)
+        print(f'Loader failed: {exception}')
+    finally:
+        LOADING = False
+
+
 @application.route('/load', methods=['GET', 'POST'])
 def load():
     """
     Loads embeddings and models once the server is running.
     """
     global LOADING  # pylint: disable=global-statement
+    global LOAD_ERROR  # pylint: disable=global-statement
+
+    status_only = request.method == 'GET' and request.args.get('status', 'false').lower() == 'true'
+    if status_only:
+        status = 'not_started'
+        if LOADED:
+            status = 'loaded'
+        elif LOADING:
+            status = 'loading'
+        elif LOAD_ERROR:
+            status = 'error'
+        response = {'status': status}
+        if LOAD_ERROR:
+            response['error'] = LOAD_ERROR
+        return jsonify(response)
+
     if LOADED:
         return jsonify({'status': 'loaded'})
     if LOADING:
         return jsonify({'status': 'loading'}), 202
 
     LOADING = True
-    try:
-        run_loader()
-        return jsonify({'status': 'loaded'})
-    except Exception as exception:  # pylint: disable=broad-except
-        return jsonify({'status': 'error', 'error': str(exception)}), 500
-    finally:
-        LOADING = False
+    LOAD_ERROR = None
+    loader_thread = threading.Thread(target=run_loader_in_background, daemon=True)
+    loader_thread.start()
+    return jsonify({'status': 'loading'}), 202
 
 
 if not os.getenv('PRODUCTION', 'false').lower() == 'true':

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -37,7 +37,7 @@ else
 fi
 
 # Start the web server
-if [ "$DEBUG" = "true" ]; then
+if [ "$DEBUG" = "true" ] && [ "$PRODUCTION" != "true" ]; then
     echo "Starting Flask server..."
     python -u -m app.embeddings
 
@@ -48,7 +48,8 @@ else
         --log-level DEBUG \
         --pythonpath $PYTHON_PATH \
         --workers 1 \
-        --bind 0.0.0.0:80 \
+        --bind 0.0.0.0:$PORT \
         --timeout 120 \
-        --reload
+        --worker-connections 1000 \
+        --keep-alive 30
 fi

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,4 +1,6 @@
 from unittest.mock import patch
+
+import app.embeddings as embeddings_module
 from app.embeddings import application, format_distance, format_timestamp, normalise_distance
 
 
@@ -65,3 +67,118 @@ def test_format_timestamp():
     assert format_timestamp('123_45.0') == '0:45'
     assert format_timestamp('123_189.0') == '3:09'
     assert format_timestamp('123_999.123') == '16:39'
+
+
+def test_load_status_not_started():
+    """
+    Status endpoint reports not_started before loading starts.
+    """
+    with patch.object(embeddings_module, 'LOADED', False), \
+            patch.object(embeddings_module, 'LOADING', False), \
+            patch.object(embeddings_module, 'LOAD_ERROR', None):
+        with application.test_client() as client:
+            response = client.get('/load?status=true')
+            assert response.status_code == 200
+            assert response.json == {'status': 'not_started'}
+
+
+def test_load_status_loading():
+    """
+    Status endpoint reports loading while a load is in progress.
+    """
+    with patch.object(embeddings_module, 'LOADED', False), \
+            patch.object(embeddings_module, 'LOADING', True), \
+            patch.object(embeddings_module, 'LOAD_ERROR', None):
+        with application.test_client() as client:
+            response = client.get('/load?status=true')
+            assert response.status_code == 200
+            assert response.json == {'status': 'loading'}
+
+
+def test_load_status_loaded():
+    """
+    Status endpoint reports loaded once loading is complete.
+    """
+    with patch.object(embeddings_module, 'LOADED', True), \
+            patch.object(embeddings_module, 'LOADING', False), \
+            patch.object(embeddings_module, 'LOAD_ERROR', None):
+        with application.test_client() as client:
+            response = client.get('/load?status=true')
+            assert response.status_code == 200
+            assert response.json == {'status': 'loaded'}
+
+
+def test_load_status_error():
+    """
+    Status endpoint reports loader errors.
+    """
+    with patch.object(embeddings_module, 'LOADED', False), \
+            patch.object(embeddings_module, 'LOADING', False), \
+            patch.object(embeddings_module, 'LOAD_ERROR', 'boom'):
+        with application.test_client() as client:
+            response = client.get('/load?status=true')
+            assert response.status_code == 200
+            assert response.json == {'status': 'error', 'error': 'boom'}
+
+
+@patch('app.embeddings.threading.Thread')
+def test_load_starts_background_thread(mock_thread):
+    """
+    GET /load triggers loading in a background thread.
+    """
+    thread = mock_thread.return_value
+    with patch.object(embeddings_module, 'LOADED', False), \
+            patch.object(embeddings_module, 'LOADING', False), \
+            patch.object(embeddings_module, 'LOAD_ERROR', 'previous_error'):
+        with application.test_client() as client:
+            response = client.get('/load')
+            assert response.status_code == 202
+            assert response.json == {'status': 'loading'}
+        assert embeddings_module.LOADING is True
+        assert embeddings_module.LOAD_ERROR is None
+
+    mock_thread.assert_called_once_with(
+        target=embeddings_module.run_loader_in_background,
+        daemon=True,
+    )
+    thread.start.assert_called_once_with()
+
+
+@patch('app.embeddings.threading.Thread')
+def test_load_returns_loaded_when_ready(mock_thread):
+    """
+    /load returns loaded when loader has already completed.
+    """
+    with patch.object(embeddings_module, 'LOADED', True), \
+            patch.object(embeddings_module, 'LOADING', False):
+        with application.test_client() as client:
+            response = client.get('/load')
+            assert response.status_code == 200
+            assert response.json == {'status': 'loaded'}
+    mock_thread.assert_not_called()
+
+
+@patch('app.embeddings.threading.Thread')
+def test_load_returns_loading_when_in_progress(mock_thread):
+    """
+    /load returns loading when loader is already in progress.
+    """
+    with patch.object(embeddings_module, 'LOADED', False), \
+            patch.object(embeddings_module, 'LOADING', True):
+        with application.test_client() as client:
+            response = client.get('/load')
+            assert response.status_code == 202
+            assert response.json == {'status': 'loading'}
+    mock_thread.assert_not_called()
+
+
+@patch('app.embeddings.run_loader', side_effect=Exception('boom'))
+def test_run_loader_in_background_sets_error_and_resets_loading(_):
+    """
+    Background loader wrapper persists error and clears loading state.
+    """
+    with patch.object(embeddings_module, 'LOADING', True), \
+            patch.object(embeddings_module, 'LOAD_ERROR', None):
+        embeddings_module.run_loader_in_background()
+        assert embeddings_module.LOADING is False
+        assert embeddings_module.LOAD_ERROR == 'boom'


### PR DESCRIPTION
Resolves #16

Let's avoid loading embeddings until after the server has booted.

### Acceptance Criteria
- [x] Load embeddings after the server is up and responding

### Relevant design files
* None

### Testing instructions
1. Set `PRODUCTION=true` and `make build`
1. Note you get empty embeddings: http://localhost:8081/?json=true
1. Load them by hitting: http://localhost:8081/load
1. Note you see it change to `loading`: http://localhost:8081/load